### PR TITLE
test: Improve jest memory usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1459,7 +1459,7 @@
     "lint:fix": "npm run lint -- --fix",
     "lint:prettier": "prettier -w src __tests__",
     "lint:format": "npm run lint:prettier && npm run lint:fix",
-    "test": "node --expose-gc node_modules/jest/bin/jest",
+    "test": "node --no-compilation-cache --expose-gc node_modules/.bin/jest",
     "test:coverage": "npm test -- --coverage",
     "test:ci": "npm run test:coverage -- --no-cache --ci --verbose --runInBand --logHeapUsage",
     "docs": "typedoc && node scripts/docs.js",

--- a/package.json
+++ b/package.json
@@ -1459,7 +1459,7 @@
     "lint:fix": "npm run lint -- --fix",
     "lint:prettier": "prettier -w src __tests__",
     "lint:format": "npm run lint:prettier && npm run lint:fix",
-    "test": "node --no-compilation-cache --expose-gc node_modules/.bin/jest",
+    "test": "node --no-compilation-cache --expose-gc node_modules/jest/bin/jest",
     "test:coverage": "npm test -- --coverage",
     "test:ci": "npm run test:coverage -- --no-cache --ci --verbose --runInBand --logHeapUsage",
     "docs": "typedoc && node scripts/docs.js",


### PR DESCRIPTION
Based on [this](https://github.com/facebook/jest/issues/11956#issuecomment-991796821) comment!

It seems to be more stable in regards to memory usage this way.

_**For reference**_: It improved final heap size from ~1GB in [here](https://github.com/ardalanamini/prototyped.js/runs/5725004437?check_suite_focus=true#step:10:2549) to ~150MB in [here](https://github.com/ardalanamini/prototyped.js/runs/5725925557?check_suite_focus=true#step:10:2549).